### PR TITLE
グループ機能 ルーティング作成

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root 'message#index'
   resources :users, only: [:edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end


### PR DESCRIPTION
# WAHT
・groupsコントローラー、messagesコントローラーのルーティングを記述

# WHY
・グループ機能を作成するためのルーティング設定
・ネストすることにより、groups_idをmessagesコントローラーで扱えるようにする
