### PR TITLE
グループ作成 編集機能

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -22,7 +22,7 @@
      background-color: #253141;
      height: 100px;
      width: 100%;
-    p {
+    p.top__name {
        color: $frequent-font-color;
        font-size:  16px;
        font-weight: bold;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
+
   def new
     @group = Group.new
     @group.users << current_user
@@ -17,4 +19,9 @@ class GroupsController < ApplicationController
   def group_params
     params.require(:group).permit(:name, { :user_ids => []})
   end
+
+  def set_group
+    @group = Group.find(params[:id])
+  end
+
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,42 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+    /
+      <div class='chat-group-form__field--left'>
+      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+      </div>
+      <div class='chat-group-form__field--right'>
+      <div class='chat-group-form__search clearfix'>
+      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+      </div>
+      <div id='user-search-result'></div>
+      </div>
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      /
+        <div id='chat-group-users'>
+        <div class='chat-group-user clearfix' id='chat-group-user-22'>
+        <input name='chat_group[user_ids][]' type='hidden' value='22'>
+        <p class='chat-group-user__name'>seo_kyohei</p>
+        </div>
+        </div>
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,33 +1,4 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{acceptcharset: "UTF-8", action: "/chat_groups/22", method: "post"}
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}/
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='chat-group-form__field--right'>
-        <div class='chat-group-form__search clearfix'>
-        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        %input.chat-group-form__action-btn{datadisablewith: "Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group }
+

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,44 +1,4 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field
-      .chat-group-form__field--left
-        = f.label :name, class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='chat-group-form__field--right'>
-        <div class='chat-group-form__search clearfix'>
-        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-        /
-          <div id='chat-group-users'>
-          <div class='chat-group-user clearfix' id='chat-group-user-22'>
-          <input name='chat_group[user_ids][]' type='hidden' value='22'>
-          <p class='chat-group-user__name'>seo_kyohei</p>
-          </div>
-          </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        %input.chat-group-form__action-btn{datadisablewith: "Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group }
+

--- a/app/views/message/index.html.haml
+++ b/app/views/message/index.html.haml
@@ -4,11 +4,13 @@
 .wrapper
   .side-bar
     .top
-      %p chabi
+      %p.top__name
+        = current_user.name
       %ul{class: "side-bar-icon"}
         = link_to new_group_path do
           %i{class: "far fa-edit edit-icon-color"}
-        %i{class: "fas fa-cog cog-icon-color",onclick: "window.open('#')"}
+        = link_to edit_user_path(current_user) do
+          %i{class: "fas fa-cog cog-icon-color"}
 
     .bottom
       - current_user.groups.each do |group|


### PR DESCRIPTION
# WHAT
## groupsコントローラーの編集
- updateを定義
　- 登録後とそうでない場合の遷都先を分岐して記述
- set_groupを定義
　- @group = Group.find(params[:id])の記述により、groupsコントローラーで活用する@groupの中身をセットしてしまう
　- before_acitonへset_groupを記述し、他のアクションが発動する前にデータをセット
## サイドバーの編集
- ログインしているユーザー名が出るようにする
- link_toで画像をクリックした際のパスを指定
## グループ作成と編集画面のフォームを共通化
- 共通のフォーマットを新たに作成
- 共通部分はそれぞれのファイルにrenderで共用ファイルを指定

# WHY
グループ編集機能を実装するため