### PR TITLE
メッセージ送信 Carrierwave導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,4 +54,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem 'erb2haml'
 gem 'devise'
+gem 'carrierwave'
+gem 'mini_magick'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,10 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (10.0.2)
+    carrierwave (1.3.1)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -97,6 +101,10 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -193,6 +201,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   erb2haml
@@ -200,6 +209,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.5)
   puma (~> 3.0)
   rails (~> 5.0.1)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,4 +3,5 @@ class Message < ApplicationRecord
   belongs_to :user
 
   validates :content, presence: true, unless: :image?
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  process resize_to_fit: [800, 800]
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end


### PR DESCRIPTION
# WHAT
Carrierwaveを導入する
## 必要なgemを導入しmessageモデルで使用できるように記述する
- gemファイルへ対象のgemを記述
　- 「carrierwave」を導入することによりImageUploaderクラスを作成し画像のアップロードを使えるようにする
　- 「mini_magick」を導入することによりアップロードする画像の設定を指示することが可能
- messageモデルへUploaderを活用できるよう記述 
  - ImageUploaderをimageカラムとして使用できるように記述
- image_uploader.rbを編集
  - include CarrierWave::MiniMagickのコメントアウトを消してアクティブにする
  - process resize_to_fit: [800, 800]を記述し、縦横比を保ったまま800pxの大きさで保存できるようにする
# WHY
メッセージ送信時に画像を添付できるようにする 