### PR TITLE
メッセージ送信 グループにメッセージ表示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-
+*.jpg
+*.png
+*.jpeg
 # Ignore Byebug command history file.
 .byebug_history

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -95,7 +95,7 @@
          height: 40px;
        }
    }
-   .message {
+   .messages {
      height: 485px;
      width: 100%;
      background-color: #F7F9FC;
@@ -112,6 +112,21 @@
        padding-top: 10px;
        padding-left: 40px;
      }
+
+     .upper-message__user-name {
+       font-size: 16px;
+       font-weight: bold;
+       color: #434A54;
+       padding-top: 46px;
+       padding-left: 40px;
+     }
+     .upper-message__date {
+       font-size: 10px;
+       padding-left: 100px;
+       top: -18px;
+       position: relative;
+
+      }
    }
    .send {
     height: 90px;

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .upper-massage
+    .upper-message__user-name
+      = message.user.name
+    .upper-message__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .lower-meesage
+    - if message.content.present?
+      %p.lower-message__content
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -33,9 +33,8 @@
       %p Members: chabi 山田太郎 田中花子 鈴木次郎
       %input{onclick: "window.open('#')", type: "button", value: "Edit", name: "button", class: "chat-main-edit__button"}
 
-    .message
-      %h3 chabi
-      %p aaa
+    .messages
+      = render @messages
       %h3 chabi
       %p bbb
       %h3 chabi

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+
 module ChatSpace
   class Application < Rails::Application
     config.generators do |g|
@@ -14,6 +15,7 @@ module ChatSpace
       g.helper false
       g.test_framework false
       config.i18n.default_locale = :ja
+      config.time_zone = "Tokyo"
     end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
# WHAT
メッセージ表示画面にグループごとの投稿メッセージを表示させる
## アップロードした画像をgitの管理外とする
- gitignoreへ記述

## 時刻表示が日本時間でなかったため、修正
- config/application.rbで設定へ記述

## 時刻表示をcssで整える
- フォントサイズや表示位置を記述

## メッセージを入力内容から表示する
- renderで＠messagesのデータを渡しているのでmessageモデルを活用してデータを取得する

# WHY
仮の表示でHTMLへ直接サンプルメッセージを表示させていたので、入力内容から本文が表示されるように変更