### PR TITLE
テスト deviseをRSpecで使用

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,9 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include ControllerMacros, type: :controller
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include FactoryGirl::Syntax::Methods

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,6 @@
+module ControllerMacros
+  def login(user)
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+end


### PR DESCRIPTION
# WHAT
deviseをRSpecで使用できるようにする
## moduleを作成する
- specディレクトリの配下にsupportフォルダを作成
- supportフォルダの中にcontroller_macros.rbファイルを作成
- ファイルにログイン状態を作るメソッドを定義
## rails/helperへdeviseとmoduleを使用できるように記述
- RSpecのconfigureへdeviseが使用できるように記述
- RSpecのconfigureへ作成したモジュールを使用できるように記述
- モジュールのファイルを読み込めるように記述
# WHY
ログインしている時のしていない時の挙動をテストするため